### PR TITLE
Corrected README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To get setup, [read this documentation](docs/setup.md)
 Before you can submit flags, you have to discover the Bluetooth MAC address of your device.  Here are a couple example commands to help you find your device:
 
 Discover MAC using hcitool:   
-```` sudo hcitool blescan ````
+```` sudo hcitool lescan ````
 
 Discover MAC using bleah:   
 ```` sudo bleah ````


### PR DESCRIPTION
hcitool command to scan for BLE devices incorrectly states "hcitool blescan".  The correct command is "hcitool lescan".